### PR TITLE
Add CJK font to ISO

### DIFF
--- a/base-profile/packages.x86_64
+++ b/base-profile/packages.x86_64
@@ -102,6 +102,7 @@ blend-web-store-git
 
 # Fonts
 noto-fonts
+noto-fonts-cjk
 noto-fonts-emoji
 ttf-jetbrains-mono
 


### PR DESCRIPTION
Without `noto-fonts-cjk`, CJK texts will not be displayed.